### PR TITLE
Bugfix

### DIFF
--- a/connect/processors_toolkit/api/mixins.py
+++ b/connect/processors_toolkit/api/mixins.py
@@ -49,7 +49,6 @@ def _prepare_parameters(updated_params: List[dict]) -> List[dict]:
 def _get_new_params(resource_params: List[dict], request_params: List[dict]) -> List[dict]:
     normalized_resource_params = _prepare_parameters(resource_params)
     normalized_request_params = _prepare_parameters(request_params)
-
     return list(filter(lambda x: x not in normalized_resource_params, normalized_request_params))
 
 

--- a/connect/processors_toolkit/api/mixins.py
+++ b/connect/processors_toolkit/api/mixins.py
@@ -49,6 +49,7 @@ def _prepare_parameters(updated_params: List[dict]) -> List[dict]:
 def _get_new_params(resource_params: List[dict], request_params: List[dict]) -> List[dict]:
     normalized_resource_params = _prepare_parameters(resource_params)
     normalized_request_params = _prepare_parameters(request_params)
+
     return list(filter(lambda x: x not in normalized_resource_params, normalized_request_params))
 
 

--- a/connect/processors_toolkit/api/mixins.py
+++ b/connect/processors_toolkit/api/mixins.py
@@ -47,9 +47,9 @@ def _prepare_parameters(updated_params: List[dict]) -> List[dict]:
 
 
 def _get_new_params(resource_params: List[dict], request_params: List[dict]) -> List[dict]:
-    normalized_resource_params = _prepare_parameters(resource_params)
+    resource_params_ides = [param.get('id') for param in resource_params]
     normalized_request_params = _prepare_parameters(request_params)
-    return list(filter(lambda x: x not in normalized_resource_params, normalized_request_params))
+    return list(filter(lambda x: x.get('id') not in resource_params_ides, normalized_request_params))
 
 
 class WithAssetHelper:


### PR DESCRIPTION
The function has been updated since the array inclusion should be done by param_id instead of param object. This is because when a param has a value_error  distinct from empty string the comparison will return false and lead to a 400 - duplicated params error when notifying connect about the changes.